### PR TITLE
add static reusable date formatters for fixed data types, with Apple …

### DIFF
--- a/CleanroomDateTime.xcodeproj/project.pbxproj
+++ b/CleanroomDateTime.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3B475CD91DB46F4F0047D397 /* TimeIntervalComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B475CD11DB46F4F0047D397 /* TimeIntervalComponents.swift */; };
 		3B475CDA1DB46F4F0047D397 /* TimeIntervalLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B475CD21DB46F4F0047D397 /* TimeIntervalLiterals.swift */; };
 		3B90590D1DAECB5200B4EEC0 /* CleanroomDateTime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B9059031DAECB5200B4EEC0 /* CleanroomDateTime.framework */; };
+		4B596E141F7539DF004CE9F0 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B596E131F7539DF004CE9F0 /* Formatter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,6 +49,7 @@
 		3B90592C1DAECD9800B4EEC0 /* Info-Tests.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Tests.plist"; sourceTree = "<group>"; };
 		3BDB18211F15B30800803117 /* Info-Target.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Target.plist"; sourceTree = "<group>"; };
 		3BDB18221F15B32100803117 /* Target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Target.xcconfig; sourceTree = "<group>"; };
+		4B596E131F7539DF004CE9F0 /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +79,7 @@
 				3B475CCD1DB46F4F0047D397 /* DateFormatting.swift */,
 				3B475CCE1DB46F4F0047D397 /* DateManipulation.swift */,
 				3B475CCF1DB46F4F0047D397 /* DateParsing.swift */,
+				4B596E131F7539DF004CE9F0 /* Formatter.swift */,
 				3B475CD01DB46F4F0047D397 /* StandardDateFormat.swift */,
 				3B475CD11DB46F4F0047D397 /* TimeIntervalComponents.swift */,
 				3B475CD21DB46F4F0047D397 /* TimeIntervalLiterals.swift */,
@@ -249,6 +252,7 @@
 				3B475CD71DB46F4F0047D397 /* DateParsing.swift in Sources */,
 				3B475CDA1DB46F4F0047D397 /* TimeIntervalLiterals.swift in Sources */,
 				3B475CD91DB46F4F0047D397 /* TimeIntervalComponents.swift in Sources */,
+				4B596E141F7539DF004CE9F0 /* Formatter.swift in Sources */,
 				3B475CD61DB46F4F0047D397 /* DateManipulation.swift in Sources */,
 				3B475CD31DB46F4F0047D397 /* BooleanDateChecks.swift in Sources */,
 				3B475CD51DB46F4F0047D397 /* DateFormatting.swift in Sources */,

--- a/Sources/DateFormatting.swift
+++ b/Sources/DateFormatting.swift
@@ -200,6 +200,6 @@ extension Date
     public func asISO8601(inLocalTime: Bool = false)
       -> String
     {
-        return asString(format: .iso8601, inLocalTime: inLocalTime)
+        return asString(format: .iso8601DateTime, inLocalTime: inLocalTime)
     }
 }

--- a/Sources/DateParsing.swift
+++ b/Sources/DateParsing.swift
@@ -23,11 +23,7 @@ extension String
     public func asDateRFC1123()
         -> Date?
     {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = StandardDateFormat.rfc1123.rawValue
-        return formatter.date(from: self)
+        return Date.Formatter.rfc1123.date(from: self)
     }
 
     /**
@@ -40,10 +36,18 @@ extension String
     public func asDateISO8601()
         -> Date?
     {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: Locale.current.identifier)
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = StandardDateFormat.iso8601.rawValue
-        return formatter.date(from: self)
+        /** Chain of parsers solves the issue when services use different
+         date formats with millisonds of even without time */
+
+        if let date = Date.Formatter.iso8601DateTimeMillis.date(from: self) {
+            return date
+        }
+        if let date = Date.Formatter.iso8601DateTime.date(from: self) {
+            return date
+        }
+        if let date = Date.Formatter.iso8601Date.date(from: self) {
+            return date
+        }
+        return nil
     }
 }

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -1,0 +1,78 @@
+//
+//  Formatter.swift
+//  CleanroomDateTime
+//
+//  Created by Nikita Korchagin on 22/09/2017.
+//  Copyright © 2017 Gilt Groupe. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Formatters are expinsive to create. It's important to not unnecessarily create
+ and destroy formatters that you're likely to need again. In WWDC 2012 video,
+ iOS App Performance: Responsiveness,
+ https://developer.apple.com/videos/wwdc/2012/?id=235
+
+ Apple explicitly encourages us to:
+     - Cache one formatter per date format;
+     - Add observer for NSLocale.currentLocaleDidChangeNotification through the
+       NSNotificationCenter, and clearing resetting cached formatters if this occurs;
+     - resetting a format is as expensive as recreating, so avoid repeatedly changing
+       a formatter's format string.
+
+ Bottom line, reuse date formatters wherever possible if you're using the same date format repeatedly.
+ */
+
+extension Date {
+    struct Formatter {
+
+        private static let ThreadDictionaryKeyPrefix = "CleanroomDateTimeFormatter-"
+
+        //MARK: Fixed-format dates
+
+        /**
+         If using NSDateFormatter to parse date strings to be exchanged with a
+         web service (or stored in a database), you should use en_US_POSIX locale
+         to avoid problems with international users who might not be using
+         Gregorian calendars. See Apple Technical Q&A #1480.
+         https://developer.apple.com/library/content/qa/qa1480/_index.html
+         */
+        private static func fixedDateFormatter(format: String) -> DateFormatter {
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .iso8601)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = format
+            return formatter
+        }
+
+        static let iso8601Date: DateFormatter = {
+            return fixedDateFormatter(format: StandardDateFormat.iso8601Date.rawValue)
+        }()
+
+        static let iso8601DateTime: DateFormatter = {
+            return fixedDateFormatter(format: StandardDateFormat.iso8601DateTime.rawValue)
+        }()
+
+        static let iso8601DateTimeMillis: DateFormatter = {
+            return fixedDateFormatter(format: StandardDateFormat.iso8601DateTimeMillis.rawValue)
+        }()
+
+        static let rfc1123: DateFormatter = {
+            return fixedDateFormatter(format: StandardDateFormat.iso8601DateTimeMillis.rawValue)
+        }()
+
+        //MARK: User-visible dates
+
+        /**
+         If formatting date strings for the user interface, localize the strings
+         by avoiding using string literals dateFormat if possible. Use dateStyle
+         and timeStyle where you can. And if you must use custom dateFormat,
+         use templates to localize your strings. See Apple Technical Q&A #1480.
+         https://developer.apple.com/library/content/qa/qa1480/_index.html
+         */
+
+        //TODO: create a collection with reusable common formatters styles, probably in threadDictionary and store them with autoupdating current timezone and autoupdating current locale
+    }
+}

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -25,9 +25,7 @@ import Foundation
  */
 
 extension Date {
-    struct Formatter {
-
-        private static let ThreadDictionaryKeyPrefix = "CleanroomDateTimeFormatter-"
+    public struct Formatter {
 
         //MARK: Fixed-format dates
 
@@ -47,19 +45,19 @@ extension Date {
             return formatter
         }
 
-        static let iso8601Date: DateFormatter = {
+        public static let iso8601Date: DateFormatter = {
             return fixedDateFormatter(format: StandardDateFormat.iso8601Date.rawValue)
         }()
 
-        static let iso8601DateTime: DateFormatter = {
+        public static let iso8601DateTime: DateFormatter = {
             return fixedDateFormatter(format: StandardDateFormat.iso8601DateTime.rawValue)
         }()
 
-        static let iso8601DateTimeMillis: DateFormatter = {
+        public static let iso8601DateTimeMillis: DateFormatter = {
             return fixedDateFormatter(format: StandardDateFormat.iso8601DateTimeMillis.rawValue)
         }()
 
-        static let rfc1123: DateFormatter = {
+        public static let rfc1123: DateFormatter = {
             return fixedDateFormatter(format: StandardDateFormat.iso8601DateTimeMillis.rawValue)
         }()
 

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -60,17 +60,5 @@ extension Date {
         public static let rfc1123: DateFormatter = {
             return fixedDateFormatter(format: StandardDateFormat.iso8601DateTimeMillis.rawValue)
         }()
-
-        //MARK: User-visible dates
-
-        /**
-         If formatting date strings for the user interface, localize the strings
-         by avoiding using string literals dateFormat if possible. Use dateStyle
-         and timeStyle where you can. And if you must use custom dateFormat,
-         use templates to localize your strings. See Apple Technical Q&A #1480.
-         https://developer.apple.com/library/content/qa/qa1480/_index.html
-         */
-
-        //TODO: create a collection with reusable common formatters styles, probably in threadDictionary and store them with autoupdating current timezone and autoupdating current locale
     }
 }

--- a/Sources/StandardDateFormat.swift
+++ b/Sources/StandardDateFormat.swift
@@ -18,7 +18,9 @@ public enum StandardDateFormat: String
      [RFC 1123](https://www.ietf.org/rfc/rfc1123.txt) date. */
     case rfc1123 = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
-    /** The date format string representing an
+    /** The date format strings representing an
      [ISO 8601](http://www.w3.org/TR/NOTE-datetime) date. */
-    case iso8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    case iso8601Date = "yyyy-MM-dd"
+    case iso8601DateTime = "yyyy-MM-dd'T'HH:mm:ssZ"
+    case iso8601DateTimeMillis = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 }


### PR DESCRIPTION
…best practices and recommendations. Solve issue with ISO8601 Date parsing

Initially I would like to solve issue with different date formats which we can get from our ApiBuilder services, but while looking at CleanroomDateTime mentioned that we do not reuse formatters which expensive to create over and over again. And formatters which we use for parsing non-user-facing dates, should be setup by Apple Q&A recommendations. So, I started process in that direction. Formatters for network/web layers are done, but there are TODOs:
1) Investigate, can we reuse some often used user-facing formatters, it can improve performance and UI responsiveness. We have 2 approaches here, listen to NSLocalChanged notification and reset our cache, or use autoupdating current timezone and autoupdating current locale. Apple claimed that it also will work, but I never used them before in practice.
2) Use static date formatters in bottom DateFormatting file, where we perform formatting for dates which supposed to reflect technical non-user-facing dates and used in web communications, but I did not touched that part as I see you used timezone there, so if we will need timezone, maybe we can refactor that part, so proper locale will be used if we pass data to service as param.